### PR TITLE
specify the input shape in the first layer

### DIFF
--- a/LearnDigitz/keras_train.py
+++ b/LearnDigitz/keras_train.py
@@ -50,7 +50,7 @@ def mlp():
 
 def cnn():
   return Sequential([
-    Reshape((28, 28, 1)),
+    Reshape((28, 28, 1), input_shape=(784, 1)),
     Conv2D(32, [5, 5], padding='same', activation='relu'),
     MaxPooling2D(strides=2),
     Conv2D(64, [5, 5], padding='same', activation='relu'),

--- a/LearnDigitz/keras_train.py
+++ b/LearnDigitz/keras_train.py
@@ -50,7 +50,7 @@ def mlp():
 
 def cnn():
   return Sequential([
-    Reshape((28, 28, 1), input_shape=(784, 1)),
+    Reshape((28, 28, 1), input_shape=(784, )),
     Conv2D(32, [5, 5], padding='same', activation='relu'),
     MaxPooling2D(strides=2),
     Conv2D(64, [5, 5], padding='same', activation='relu'),


### PR DESCRIPTION
Keras '2.1.6-tf' needs an input shape in this layer so it can save the model, otherwise it prints this error: 

```bash
NotImplementedError                       Traceback (most recent call last)
<ipython-input-4-99efa4bdc06e> in <module>()
      1 
----> 2 model.save('epic_num_reader.model')

NotImplementedError: Currently `save` requires model to be a graph network. Consider using `save_weights`, in order to save the weights of the model.
```